### PR TITLE
Add grade indexing

### DIFF
--- a/mp_scraper/grades.py
+++ b/mp_scraper/grades.py
@@ -144,7 +144,7 @@ class Ice(Grade):
         else:
             logging.error(f"Unrecognized grade pattern {self.grade}")
 
-        # Subtract 1 from the grade so that the range is 0-8 instead of 1-8
+        # Subtract 1 from the grade so that the range is 0-7 instead of 1-8
         return (number_grade - 1) * 3 + offset
 
 
@@ -177,6 +177,47 @@ class Aid(Grade):
             logging.error(f"Unrecognized grade pattern {self.grade}")
 
         return number_grade * 3 + offset
+
+
+class Mixed(Grade):
+    def index(self):
+        """Get the sorting index for an Ice climbing grade
+        Indexing goes from M1-M9
+        Each grade is defined as having 3 potential values ordered as follows: Mx-, Mx, Mx+
+        Mx-y grades are treated as equal to Mx+
+        """
+
+        # Remove the 'M' prefix
+        mixed_grade = self.grade[1:]
+
+        number_grade = None
+        offset = 1  # An offset of 1 brings us to the index for Mx
+
+        if all(char.isdigit() for char in mixed_grade):
+            # Mx
+            number_grade = int(mixed_grade)
+        elif re.match(r"\d+-\d+", mixed_grade) is not None:
+            # Mx-y
+            number_grade = int(re.match(r"(\d+)-\d+", mixed_grade)[1])
+            offset += 1  # An offset of 2 brings us to the index for Mx+
+        elif "+" in mixed_grade:
+            # Mx+
+            number_grade = int(mixed_grade[:-1])
+            offset += 1
+        elif "-" in mixed_grade:
+            # Mx-
+            number_grade = int(mixed_grade[:-1])
+            offset -= 1  # An offset of 0 brings us to the index for Mx-
+        else:
+            logging.error(f"Unrecognized grade pattern {self.grade}")
+
+        # Subtract 1 from the grade so that the range is 0-9 instead of 1-10
+        return (number_grade - 1) * 3 + offset
+
+
+class Snow(Grade):
+    def index(self):
+        return ["Easy Snow", "Mod. Snow", "Steep Snow"].index(self.grade)
 
 
 class Danger(Grade):

--- a/mp_scraper/grades.py
+++ b/mp_scraper/grades.py
@@ -2,13 +2,14 @@ import logging
 import re
 
 
-class YDS:
+class Grade:
+    def __init__(self, grade):
+        self.grade = grade
+
+class YDS(Grade):
     static_indexes = ["3rd", "4th", "Easy 5th"]
     single_digit_mplier = 3
     double_digit_mplier = 7
-
-    def __init__(self, grade):
-        self.grade = grade
 
     def index(self):
         """ Get the sorting index for a YDS grade
@@ -70,10 +71,7 @@ class YDS:
         return index
 
 
-class Hueco:
-    def __init__(self, grade):
-        self.grade = grade
-
+class Hueco(Grade):
     def index(self):
         """Get the sorting index for a Hueco grade
 
@@ -96,7 +94,6 @@ class Hueco:
             number_grade = int(v_grade)
         elif re.match(r"\d+-\d+", v_grade) is not None:
             # Vx-y
-            print("Match")
             number_grade = int(re.match(r"(\d+)-\d+", v_grade)[1])
             offset += 1 # An offset of 2 brings us to the index for Vx+
         elif "+" in v_grade:
@@ -111,3 +108,39 @@ class Hueco:
             logging.error(f"Unrecognized grade pattern {self.grade}")
 
         return number_grade * 3 + offset + 1 # Add 1 to account for VB/V-easy
+
+class Ice(Grade):
+    def index(self):
+        """Get the sorting index for an Ice climbing grade
+        Indexing goes from WI1-WI8
+        Each grade is defined as having 3 potential values ordered as follows: WIx-, WIx, WIx+
+        WIx-y grades are treated as equal to WIx+ 
+        AIx grades are treated as equal to WIx
+        """
+
+        # Remove the 'WI'/'AI' prefix
+        ice_grade = self.grade[2:]
+
+        number_grade = None
+        offset = 1  # An offset of 1 brings us to the index for Ix
+
+        if all(char.isdigit() for char in ice_grade):
+            # Ix
+            number_grade = int(ice_grade)
+        elif re.match(r"\d+-\d+", ice_grade) is not None:
+            # Ix-y
+            number_grade = int(re.match(r"(\d+)-\d+", ice_grade)[1])
+            offset += 1 # An offset of 2 brings us to the index for Ix+
+        elif "+" in ice_grade:
+            # Ix+
+            number_grade = int(ice_grade[:-1])
+            offset += 1
+        elif "-" in ice_grade:
+            # Ix-
+            number_grade = int(ice_grade[:-1])
+            offset -= 1  # An offset of 0 brings us to the index for Ix-
+        else:
+            logging.error(f"Unrecognized grade pattern {self.grade}")
+
+        # Subtract 1 from the grade so that the range is 0-8 instead of 1-8
+        return (number_grade - 1) * 3 + offset

--- a/mp_scraper/grades.py
+++ b/mp_scraper/grades.py
@@ -1,0 +1,113 @@
+import logging
+import re
+
+
+class YDS:
+    static_indexes = ["3rd", "4th", "Easy 5th"]
+    single_digit_mplier = 3
+    double_digit_mplier = 7
+
+    def __init__(self, grade):
+        self.grade = grade
+
+    def index(self):
+        """ Get the sorting index for a YDS grade
+        Each grade from 5.0 to 5.9 is defined as having 3 potential values ordered as follows: 5.x-, 5.x, 5.x+
+        Each grade 5.10 and above is defined as having 8 potential values ordered as follows: 5.xxa, 5.xxa/b, 5.xxb, 5.xxb/c, 5.xx, 5.xxc, 5.xxc/d, 5.xxd
+        -/+ grades for 5.10 and above are treated as equal to 5.xxa/b and 5.xxc/d respectively
+        5.xx grades are treated as equal to 5.xxb/c
+        """
+        if self.grade in self.static_indexes:
+            return self.static_indexes.index(self.grade)
+
+        # Remove the '5.' prefix
+        fifth_grade = self.grade[2:]
+
+        # Start after last position of static_indexes
+        index = len(self.static_indexes)
+
+        if len(fifth_grade) == 1:
+            # 5.x case
+            index += int(fifth_grade) * self.single_digit_mplier + 1
+        elif not fifth_grade[1].isdigit():
+            # 5.x +/- case
+            offset = 1  # An offset of 1 brings us to the index for 5.x
+            # Add 1 for 5.x+, subtract for 5.x-
+            offset += 1 if fifth_grade[1] == "+" else -1
+
+            index += int(fifth_grade[0]) * self.single_digit_mplier + offset
+        else:
+            # 5.xx case
+            index += 29  # Start after last position of single digit grades
+            offset = 4  # An offset of 4 brings us to the index for 5.xxb/c
+
+            if fifth_grade[-1] == "a":
+                # 5.xxa
+                offset -= 3
+            elif "a/b" in fifth_grade or "-" in fifth_grade:
+                # 5.xxa/b or 5.xx-
+                offset -= 2
+            elif fifth_grade[-1] == "b":
+                # 5.xxb
+                offset -= 1
+            elif "b/c" in fifth_grade or fifth_grade[-1].isdigit():
+                # 5.xxb/c or 5.xx
+                pass
+            elif fifth_grade[-1] == "c":
+                # 5.xxc
+                offset += 1
+            elif "c/d" in fifth_grade or "+" in fifth_grade:
+                # 5.xxc/d or 5.xx+
+                offset += 2
+            elif fifth_grade[-1] == "d":
+                # 5.xxd
+                offset += 3
+            else:
+                logging.error(f"Unrecognized grade format {self.grade}")
+
+            index += int(fifth_grade[1]) * self.double_digit_mplier + offset
+
+        return index
+
+
+class Hueco:
+    def __init__(self, grade):
+        self.grade = grade
+
+    def index(self):
+        """Get the sorting index for a Hueco grade
+
+        Indexing goes from VB to V17
+        Each grade is defined as having 3 potential values ordered as follows: Vx-, Vx, Vx+
+        Vx-y grades are treated as equal to Vx+
+        V-easy grades are treated as equal to VB
+        """
+        if self.grade in ["V-easy", "VB"]:
+            return 0
+        
+        # Remove the 'V' prefix
+        v_grade = self.grade[1:]
+
+        number_grade = None
+        offset = 1  # An offset of 1 brings us to the index for Vx
+
+        if all(char.isdigit() for char in v_grade):
+            # Vx or Vxx
+            number_grade = int(v_grade)
+        elif re.match(r"\d+-\d+", v_grade) is not None:
+            # Vx-y
+            print("Match")
+            number_grade = int(re.match(r"(\d+)-\d+", v_grade)[1])
+            offset += 1 # An offset of 2 brings us to the index for Vx+
+        elif "+" in v_grade:
+            # Vx+
+            number_grade = int(v_grade[:-1])
+            offset += 1
+        elif "-" in v_grade:
+            # Vx-
+            number_grade = int(v_grade[:-1])
+            offset -= 1  # An offset of 0 brings us to the index for Vx-
+        else:
+            logging.error(f"Unrecognized grade pattern {self.grade}")
+
+        return number_grade * 3 + offset + 1 # Add 1 to account for VB/V-easy

--- a/mp_scraper/grades.py
+++ b/mp_scraper/grades.py
@@ -6,6 +6,7 @@ class Grade:
     def __init__(self, grade):
         self.grade = grade
 
+
 class YDS(Grade):
     static_indexes = ["3rd", "4th", "Easy 5th"]
     single_digit_mplier = 3
@@ -82,7 +83,7 @@ class Hueco(Grade):
         """
         if self.grade in ["V-easy", "VB"]:
             return 0
-        
+
         # Remove the 'V' prefix
         v_grade = self.grade[1:]
 
@@ -95,7 +96,7 @@ class Hueco(Grade):
         elif re.match(r"\d+-\d+", v_grade) is not None:
             # Vx-y
             number_grade = int(re.match(r"(\d+)-\d+", v_grade)[1])
-            offset += 1 # An offset of 2 brings us to the index for Vx+
+            offset += 1  # An offset of 2 brings us to the index for Vx+
         elif "+" in v_grade:
             # Vx+
             number_grade = int(v_grade[:-1])
@@ -107,7 +108,8 @@ class Hueco(Grade):
         else:
             logging.error(f"Unrecognized grade pattern {self.grade}")
 
-        return number_grade * 3 + offset + 1 # Add 1 to account for VB/V-easy
+        return number_grade * 3 + offset + 1  # Add 1 to account for VB/V-easy
+
 
 class Ice(Grade):
     def index(self):
@@ -130,7 +132,7 @@ class Ice(Grade):
         elif re.match(r"\d+-\d+", ice_grade) is not None:
             # Ix-y
             number_grade = int(re.match(r"(\d+)-\d+", ice_grade)[1])
-            offset += 1 # An offset of 2 brings us to the index for Ix+
+            offset += 1  # An offset of 2 brings us to the index for Ix+
         elif "+" in ice_grade:
             # Ix+
             number_grade = int(ice_grade[:-1])
@@ -144,3 +146,8 @@ class Ice(Grade):
 
         # Subtract 1 from the grade so that the range is 0-8 instead of 1-8
         return (number_grade - 1) * 3 + offset
+
+
+class Danger(Grade):
+    def index(self):
+        return ["PG13", "R", "X"].index(self.grade)

--- a/mp_scraper/grades.py
+++ b/mp_scraper/grades.py
@@ -148,6 +148,37 @@ class Ice(Grade):
         return (number_grade - 1) * 3 + offset
 
 
+class Aid(Grade):
+    def index(self):
+        """Get the sorting index for an Aid climbing grade
+        Indexing goes from A1-A8
+        Each grade is defined as having 3 potential values ordered as follows: Ax-, Ax, Ax+
+        Cx grades are treated as equal to Ax
+        """
+
+        # Remove the 'A'/'C' prefix
+        ice_grade = self.grade[1:]
+
+        number_grade = None
+        offset = 1  # An offset of 1 brings us to the index for Ax
+
+        if all(char.isdigit() for char in ice_grade):
+            # Ax
+            number_grade = int(ice_grade)
+        elif "+" in ice_grade:
+            # Ax+
+            number_grade = int(ice_grade[:-1])
+            offset += 1
+        elif "-" in ice_grade:
+            # Ax-
+            number_grade = int(ice_grade[:-1])
+            offset -= 1  # An offset of 0 brings us to the index for Ax-
+        else:
+            logging.error(f"Unrecognized grade pattern {self.grade}")
+
+        return number_grade * 3 + offset
+
+
 class Danger(Grade):
     def index(self):
         return ["PG13", "R", "X"].index(self.grade)

--- a/mp_scraper/grades.py
+++ b/mp_scraper/grades.py
@@ -6,6 +6,12 @@ class Grade:
     def __init__(self, grade):
         self.grade = grade
 
+    def to_dict(self):
+        return { "grade": self.grade, "sort_index": self.index() }
+
+    def index(self):
+        pass
+
 
 class YDS(Grade):
     static_indexes = ["3rd", "4th", "Easy 5th"]
@@ -30,6 +36,7 @@ class YDS(Grade):
 
         if len(fifth_grade) == 1:
             # 5.x case
+            # Add an offset of 1 to get to 5.x
             index += int(fifth_grade) * self.single_digit_mplier + 1
         elif not fifth_grade[1].isdigit():
             # 5.x +/- case

--- a/mp_scraper/spiders/mp.py
+++ b/mp_scraper/spiders/mp.py
@@ -187,8 +187,8 @@ class MpSpider(CrawlSpider):
             "ice": grade_info.re_first(r"[WA]I\d(?:-\d)?[\+-]?"),
             "danger": grade_info.re_first(r" (R|X|PG13)"),
             "aid": grade_info.re_first(r"[CA]\d\+?"),
-            "m": grade_info.re_first(r"M[\d-]+"),
-            "v": grade_info.re_first(r"V[\dB-]+[\+-]?\d*(?:easy)?"),
+            "mixed": grade_info.re_first(r"M[\d-]+"),
+            "hueco": grade_info.re_first(r"V[\dB-]+[\+-]?\d*(?:easy)?"),
             "snow": grade_info.re_first(r"\w+\.? ?Snow")
         }
 

--- a/mp_scraper/spiders/mp.py
+++ b/mp_scraper/spiders/mp.py
@@ -3,6 +3,7 @@ import calendar
 import json
 import logging
 from mp_scraper.items import Area, Route, MpItemLoader
+from mp_scraper.grades import YDS, Aid, Danger, Hueco, Ice, Mixed, Snow
 import re
 import scrapy
 from scrapy.linkextractors import LinkExtractor
@@ -183,13 +184,13 @@ class MpSpider(CrawlSpider):
         grade_info = response.css("div.col-md-9 > h2")
 
         grades = {
-            "yds": grade_info.re_first(r"(5\.[\d\w\+\-\?/]{1,5}|3rd|4th|Easy 5th)"),
-            "ice": grade_info.re_first(r"[WA]I\d(?:-\d)?[\+-]?"),
-            "danger": grade_info.re_first(r" (R|X|PG13)"),
-            "aid": grade_info.re_first(r"[CA]\d\+?"),
-            "mixed": grade_info.re_first(r"M[\d-]+"),
-            "hueco": grade_info.re_first(r"V[\dB-]+[\+-]?\d*(?:easy)?"),
-            "snow": grade_info.re_first(r"\w+\.? ?Snow")
+            "yds": YDS(grade_info.re_first(r"(5\.[\d\w\+\-\?/]{1,5}|3rd|4th|Easy 5th)")),
+            "ice": Ice(grade_info.re_first(r"[WA]I\d(?:-\d)?[\+-]?")),
+            "danger": Danger(grade_info.re_first(r" (R|X|PG13)")),
+            "aid": Aid(grade_info.re_first(r"[CA]\d\+?")),
+            "mixed": Mixed(grade_info.re_first(r"M[\d-]+")),
+            "hueco": Hueco(grade_info.re_first(r"V[\dB-]+[\+-]?\d*(?:easy)?")),
+            "snow": Snow(grade_info.re_first(r"\w+\.? ?Snow"))
         }
 
-        return {k: v for k, v in grades.items() if v is not None}
+        return {k: v.to_dict() for k, v in grades.items() if v.grade is not None}

--- a/tests/pages/expected_items.py
+++ b/tests/pages/expected_items.py
@@ -247,7 +247,7 @@ expected_items = {
             rating=4,
             link="https://www.mountainproject.com/route/109513995/invisible-touch",
             grades={
-                "v": "V8"
+                "hueco": "V8"
             }
         ),
         "planet-of-the-apes": Route(
@@ -259,7 +259,7 @@ expected_items = {
             rating=3.8,
             link="https://www.mountainproject.com/route/106318953/planet-of-the-apes",
             grades={
-                "v": "V7-"
+                "hueco": "V7-"
             }
         ),
         "the-red-house-extension": Route(
@@ -271,7 +271,7 @@ expected_items = {
             rating=3.5,
             link="https://www.mountainproject.com/route/108027966/the-red-house-extension",
             grades={
-                "v": "V7+"
+                "hueco": "V7+"
             }
         ),
         "feels-like-grit": Route(
@@ -283,7 +283,7 @@ expected_items = {
             rating=3.2,
             link="https://www.mountainproject.com/route/105938571/feels-like-grit",
             grades={
-                "v": "V6-7"
+                "hueco": "V6-7"
             }
         ),
         "black-dike": Route(
@@ -299,7 +299,7 @@ expected_items = {
             grades={
                 "yds": "5.6",
                 "ice": "WI4-5",
-                "m": "M3"
+                "mixed": "M3"
             }
         ),
         "ames-ice-hose": Route(
@@ -315,7 +315,7 @@ expected_items = {
             grades={
                 "ice": "WI5",
                 "danger": "R",
-                "m": "M6",
+                "mixed": "M6",
             }
         ),
         "cosmiques-arete": Route(
@@ -331,7 +331,7 @@ expected_items = {
             grades={
                 "yds": "5.6",
                 "ice": "AI2",
-                "m": "M4",
+                "mixed": "M4",
                 "snow": "Mod. Snow",
             }
         ),
@@ -346,7 +346,7 @@ expected_items = {
             link="https://www.mountainproject.com/route/105747482/skylight",
             grades={
                 "ice": "WI4+",
-                "m": "M4-5",
+                "mixed": "M4-5",
             }
         ),
         "rock": Route(
@@ -358,7 +358,7 @@ expected_items = {
             rating=1.0,
             link="https://www.mountainproject.com/route/107350537/rock",
             grades={
-                "v": "V-easy"
+                "hueco": "V-easy"
             }
         )
     }

--- a/tests/pages/expected_items.py
+++ b/tests/pages/expected_items.py
@@ -152,7 +152,7 @@ expected_items = {
             length="II",
             height=500,
             grades={
-                "snow": "Mod. Snow"
+                "snow": { "grade": "Mod. Snow", "sort_index": 1 }
             }
         ),
         "liberty-ridge": Route(
@@ -165,8 +165,8 @@ expected_items = {
             length="IV",
             height=10500,
             grades={
-                "ice": "AI2-3",
-                "snow": "Steep Snow"
+                "ice": { "grade": "AI2-3", "sort_index": 5 },
+                "snow": { "grade": "Steep Snow", "sort_index": 2 }
             }
         ),
         "upper-exum-ridge": Route(
@@ -180,7 +180,7 @@ expected_items = {
             height=1700,
             pitches=12,
             grades={
-                "yds": "5.5"
+                "yds": { "grade": "5.5", "sort_index": 19 }
             }
         ),
         "the-moonlight-buttress-free": Route(
@@ -193,7 +193,7 @@ expected_items = {
             height=1200,
             pitches=10,
             grades={
-                "yds": "5.12c"
+                "yds": { "grade": "5.12c", "sort_index": 51 }
             }
         ),
         "the-original-route": Route(
@@ -206,7 +206,7 @@ expected_items = {
             height=1000,
             pitches=14,
             grades={
-                "yds": "5.12-",
+                "yds": { "grade": "5.12-", "sort_index": 48 },
             }
         ),
         "regular-northwest-face-of-half-dome": Route(
@@ -220,8 +220,8 @@ expected_items = {
             length="VI",
             pitches=23,
             grades={
-                "yds": "5.9",
-                "aid": "C1",
+                "yds": { "grade": "5.9", "sort_index": 31 },
+                "aid": { "grade": "C1", "sort_index": 4 },
             }
         ),
         "moby-grape": Route(
@@ -235,8 +235,8 @@ expected_items = {
             length="III",
             pitches=7,
             grades={
-                "yds": "5.8",
-                "danger": "PG13",
+                "yds": { "grade": "5.8", "sort_index": 28 },
+                "danger": { "grade": "PG13", "sort_index": 0 },
             }
         ),
         "invisible-touch": Route(
@@ -247,7 +247,7 @@ expected_items = {
             rating=4,
             link="https://www.mountainproject.com/route/109513995/invisible-touch",
             grades={
-                "hueco": "V8"
+                "hueco": { "grade": "V8", "sort_index": 26 }
             }
         ),
         "planet-of-the-apes": Route(
@@ -259,7 +259,7 @@ expected_items = {
             rating=3.8,
             link="https://www.mountainproject.com/route/106318953/planet-of-the-apes",
             grades={
-                "hueco": "V7-"
+                "hueco": { "grade": "V7-", "sort_index": 22 }
             }
         ),
         "the-red-house-extension": Route(
@@ -271,7 +271,7 @@ expected_items = {
             rating=3.5,
             link="https://www.mountainproject.com/route/108027966/the-red-house-extension",
             grades={
-                "hueco": "V7+"
+                "hueco": { "grade": "V7+", "sort_index": 24 }
             }
         ),
         "feels-like-grit": Route(
@@ -283,7 +283,7 @@ expected_items = {
             rating=3.2,
             link="https://www.mountainproject.com/route/105938571/feels-like-grit",
             grades={
-                "hueco": "V6-7"
+                "hueco": { "grade": "V6-7", "sort_index": 21 }
             }
         ),
         "black-dike": Route(
@@ -297,9 +297,9 @@ expected_items = {
             rating=3.9,
             link="https://www.mountainproject.com/route/105890633/black-dike",
             grades={
-                "yds": "5.6",
-                "ice": "WI4-5",
-                "mixed": "M3"
+                "yds": { "grade": "5.6", "sort_index": 22 },
+                "ice": { "grade": "WI4-5", "sort_index": 11 },
+                "mixed": { "grade": "M3", "sort_index": 7 }
             }
         ),
         "ames-ice-hose": Route(
@@ -313,9 +313,9 @@ expected_items = {
             rating=4.0,
             link="https://www.mountainproject.com/route/105747549/ames-ice-hose",
             grades={
-                "ice": "WI5",
-                "danger": "R",
-                "mixed": "M6",
+                "ice": { "grade": "WI5", "sort_index": 13 },
+                "danger": { "grade": "R", "sort_index": 1 },
+                "mixed": { "grade": "M6", "sort_index": 16 },
             }
         ),
         "cosmiques-arete": Route(
@@ -329,10 +329,10 @@ expected_items = {
             rating=3.8,
             link="https://www.mountainproject.com/route/107497087/cosmiques-arete",
             grades={
-                "yds": "5.6",
-                "ice": "AI2",
-                "mixed": "M4",
-                "snow": "Mod. Snow",
+                "yds": { "grade": "5.6", "sort_index": 22 },
+                "ice": { "grade": "AI2", "sort_index": 4 },
+                "mixed": { "grade": "M4", "sort_index": 10 },
+                "snow": { "grade": "Mod. Snow", "sort_index": 1 },
             }
         ),
         "skylight": Route(
@@ -345,8 +345,8 @@ expected_items = {
             rating=3.8,
             link="https://www.mountainproject.com/route/105747482/skylight",
             grades={
-                "ice": "WI4+",
-                "mixed": "M4-5",
+                "ice": { "grade": "WI4+", "sort_index": 11 },
+                "mixed": { "grade": "M4-5", "sort_index": 11 },
             }
         ),
         "rock": Route(
@@ -358,7 +358,7 @@ expected_items = {
             rating=1.0,
             link="https://www.mountainproject.com/route/107350537/rock",
             grades={
-                "hueco": "V-easy"
+                "hueco": { "grade": "V-easy", "sort_index": 0 }
             }
         )
     }

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,4 +1,4 @@
-from mp_scraper.grades import YDS, Hueco, Ice
+from mp_scraper.grades import YDS, Hueco, Ice, Danger
 import unittest
 
 

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,4 +1,4 @@
-from mp_scraper.grades import YDS, Hueco, Ice, Danger, Aid
+from mp_scraper.grades import YDS, Hueco, Ice, Aid, Mixed
 import unittest
 
 
@@ -74,6 +74,15 @@ class TestGrades(unittest.TestCase):
             ["C2+", 8],
             ["C1-", 3],
         ], Aid)
+
+    def test_mixed(self):
+        self.run_test_matrix([
+            ["M1-", 0],
+            ["M2-3", 5],
+            ["M9-10", 26],
+            ["M8", 22],
+            ["M7-", 18]
+        ], Mixed)
 
 
 if __name__ == "__main__":

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,4 +1,4 @@
-from mp_scraper.grades import YDS, Hueco, Ice, Danger
+from mp_scraper.grades import YDS, Hueco, Ice, Danger, Aid
 import unittest
 
 
@@ -61,6 +61,19 @@ class TestGrades(unittest.TestCase):
             ["AI2+", 5],
             ["AI1-", 0],
         ], Ice)
+
+    def test_aid(self):
+        self.run_test_matrix([
+            ["A0", 1],
+            ["A2", 7],
+            ["A3+", 11],
+            ["A5", 16],
+            ["A2-", 6],
+            ["C1", 4],
+            ["C4-", 12],
+            ["C2+", 8],
+            ["C1-", 3],
+        ], Aid)
 
 
 if __name__ == "__main__":

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -4,6 +4,11 @@ import unittest
 
 class TestGrades(unittest.TestCase):
     def run_test_matrix(self, matrix, GradeType):
+        """Test grade indexing
+
+        Arguments:
+            matrix {(string, int)} -- (input, expected index)
+        """
         for case in matrix:
             with self.subTest(grade=case[0]):
                 self.assertEqual(GradeType(case[0]).index(), case[1])
@@ -11,77 +16,77 @@ class TestGrades(unittest.TestCase):
     def test_yds(self):
         with self.subTest(test="Single digit"):
             self.run_test_matrix([
-                ["3rd", 0],
-                ["4th", 1],
-                ["Easy 5th", 2],
-                ["5.0-", 3],
-                ["5.0", 4],
-                ["5.0+", 5],
-                ["5.6", 22],
-                ["5.9", 31],
-                ["5.9+", 32]
+                ("3rd", 0),
+                ("4th", 1),
+                ("Easy 5th", 2),
+                ("5.0-", 3),
+                ("5.0", 4),
+                ("5.0+", 5),
+                ("5.6", 22),
+                ("5.9", 31),
+                ("5.9+", 32)
             ], YDS)
 
         with self.subTest(test="Double digit"):
             self.run_test_matrix([
-                ["5.10a", 33],
-                ["5.11a/b", 41],
-                ["5.12-", 48],
-                ["5.13b", 56],
-                ["5.14b/c", 64],
-                ["5.15", 71],
-                ["5.10c", 37],
-                ["5.11c/d", 45],
-                ["5.12+", 52],
-                ["5.15d", 74]
+                ("5.10a", 33),
+                ("5.11a/b", 41),
+                ("5.12-", 48),
+                ("5.13b", 56),
+                ("5.14b/c", 64),
+                ("5.15", 71),
+                ("5.10c", 37),
+                ("5.11c/d", 45),
+                ("5.12+", 52),
+                ("5.15d", 74)
             ], YDS)
 
     def test_hueco(self):
         self.run_test_matrix([
-            ["V-easy", 0],
-            ["VB", 0],
-            ["V0-", 1],
-            ["V0", 2],
-            ["V0+", 3],
-            ["V6-7", 21],
-            ["V8+", 27],
-            ["V17", 53],
-            ["V17+", 54]
+            ("V-easy", 0),
+            ("VB", 0),
+            ("V0-", 1),
+            ("V0", 2),
+            ("V0+", 3),
+            ("V6-7", 21),
+            ("V8+", 27),
+            ("V17", 53),
+            ("V17+", 54)
         ], Hueco)
 
     def test_ice(self):
         self.run_test_matrix([
-            ["WI1", 1],
-            ["WI2", 4],
-            ["WI3-4", 8],
-            ["WI5+", 14],
-            ["WI2-", 3],
-            ["AI1", 1],
-            ["AI4-", 9],
-            ["AI2+", 5],
-            ["AI1-", 0],
+            ("WI1", 1),
+            ("WI2", 4),
+            ("WI3-4", 8),
+            ("WI5+", 14),
+            ("WI2-", 3),
+            ("AI1", 1),
+            ("AI4-", 9),
+            ("AI2+", 5),
+            ("AI1-", 0),
         ], Ice)
 
     def test_aid(self):
         self.run_test_matrix([
-            ["A0", 1],
-            ["A2", 7],
-            ["A3+", 11],
-            ["A5", 16],
-            ["A2-", 6],
-            ["C1", 4],
-            ["C4-", 12],
-            ["C2+", 8],
-            ["C1-", 3],
+            ("A0", 1),
+            ("A2", 7),
+            ("A3+", 11),
+            ("A5", 16),
+            ("A2-", 6),
+            ("C1", 4),
+            ("C4-", 12),
+            ("C2+", 8),
+            ("C1-", 3),
         ], Aid)
 
     def test_mixed(self):
         self.run_test_matrix([
-            ["M1-", 0],
-            ["M2-3", 5],
-            ["M9-10", 26],
-            ["M8", 22],
-            ["M7-", 18]
+            ("M1-", 0),
+            ("M2-3", 5),
+            ("M9-10", 26),
+            ("M8", 22),
+            ("M7-", 18)
         ], Mixed)
 
 

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,0 +1,54 @@
+from mp_scraper.grades import YDS, Hueco
+import unittest
+
+
+class TestGrades(unittest.TestCase):
+    def run_test_matrix(self, matrix, GradeType):
+        for case in matrix:
+            with self.subTest(grade=case[0]):
+                self.assertEqual(GradeType(case[0]).index(), case[1])
+
+    def test_yds(self):
+        with self.subTest(test="Single digit"):
+            self.run_test_matrix([
+                ["3rd", 0],
+                ["4th", 1],
+                ["Easy 5th", 2],
+                ["5.0-", 3],
+                ["5.0", 4],
+                ["5.0+", 5],
+                ["5.6", 22],
+                ["5.9", 31],
+                ["5.9+", 32]
+            ], YDS)
+
+        with self.subTest(test="Double digit"):
+            self.run_test_matrix([
+                ["5.10a", 33],
+                ["5.11a/b", 41],
+                ["5.12-", 48],
+                ["5.13b", 56],
+                ["5.14b/c", 64],
+                ["5.15", 71],
+                ["5.10c", 37],
+                ["5.11c/d", 45],
+                ["5.12+", 52],
+                ["5.15d", 74]
+            ], YDS)
+
+    def test_hueco(self):
+        self.run_test_matrix([
+            ["V-easy", 0],
+            ["VB", 0],
+            ["V0-", 1],
+            ["V0", 2],
+            ["V0+", 3],
+            ["V6-7", 21],
+            ["V8+", 27],
+            ["V17", 53],
+            ["V17+", 54]
+        ], Hueco)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grades.py
+++ b/tests/test_grades.py
@@ -1,4 +1,4 @@
-from mp_scraper.grades import YDS, Hueco
+from mp_scraper.grades import YDS, Hueco, Ice
 import unittest
 
 
@@ -48,6 +48,19 @@ class TestGrades(unittest.TestCase):
             ["V17", 53],
             ["V17+", 54]
         ], Hueco)
+
+    def test_ice(self):
+        self.run_test_matrix([
+            ["WI1", 1],
+            ["WI2", 4],
+            ["WI3-4", 8],
+            ["WI5+", 14],
+            ["WI2-", 3],
+            ["AI1", 1],
+            ["AI4-", 9],
+            ["AI2+", 5],
+            ["AI1-", 0],
+        ], Ice)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I realized as I was starting to implement endpoints utilizing this data that MongoDB's built in sorting doesn't properly sort climbing grades. On top of that, it doesn't allow for custom sorting functions which means I couldn't just roll my own sort to handle it. 

I debated manipulating cookies to get the French grades for all routes but in the end decided to go with this solution for two reasons:

1. Manipulating cookies sounded like a lot of work and I'd rather take the path of least resistance (read: I'm lazy)
2. YDS does have (for better or worse) more granularity than other systems. If I don't scrape in the finest detail I have available, I won't be able to regain that detail. 6c could be either 5.12a or 5.12b, so if I scrape in French I lose the ability to sort or filter more precisely in YDS.