### PR TITLE
Change parent_id to ancestor_ids

### DIFF
--- a/mp_scraper/items.py
+++ b/mp_scraper/items.py
@@ -14,7 +14,7 @@ class MpItemLoader(ItemLoader):
 
 class Area(scrapy.Item):
     _id = scrapy.Field()
-    parent_id = scrapy.Field()
+    ancestors = scrapy.Field(output_processor=Identity())
     name = scrapy.Field(input_processor=strip)
     latitude = scrapy.Field(input_processor=to_float)
     longitude = scrapy.Field(input_processor=to_float)
@@ -27,7 +27,7 @@ class Area(scrapy.Item):
 
 class Route(scrapy.Item):
     _id = scrapy.Field()
-    parent_id = scrapy.Field()
+    ancestors = scrapy.Field(output_processor=Identity())
     name = scrapy.Field(input_processor=strip)
     types = scrapy.Field(output_processor=Identity())
     rating = scrapy.Field(input_processor=to_float)

--- a/mp_scraper/spiders/mp.py
+++ b/mp_scraper/spiders/mp.py
@@ -39,7 +39,7 @@ class MpSpider(CrawlSpider):
 
         area_loader.add_value("link", response.url)
         area_loader.add_value("_id", id)
-        area_loader.add_value("parent_id", self.extract_parent_id(response))
+        area_loader.add_value("ancestors", self.extract_ancestor_ids(response))
         area_loader.add_css("name", "title::text",
                             re=r"(?<=[Climbing|Bouldering] in )(.+?)(?:,|$)")
 
@@ -73,7 +73,7 @@ class MpSpider(CrawlSpider):
 
         route_loader.add_value("link", response.url)
         route_loader.add_value("_id", id)
-        route_loader.add_value("parent_id", self.extract_parent_id(response))
+        route_loader.add_value("ancestors", self.extract_ancestor_ids(response))
         route_loader.add_css("name", "title::text",
                              re=r"(?<=Climb )(.+?)(?:,|$)")
         route_loader.add_css(
@@ -106,11 +106,14 @@ class MpSpider(CrawlSpider):
 
         return None
 
-    def extract_parent_id(self, response):
-        parent_link = response.css(
-            "div.mb-half.small.text-warm a::attr(href)").extract()[-1]
+    def extract_ancestor_ids(self, response):
+        parent_links = response.css(
+            "div.mb-half.small.text-warm a::attr(href)").extract()[1:]
+        
+        if len(parent_links) > 10:
+            logging.info(f"{response.url} has depth > 10")
 
-        return self.extract_id(parent_link)
+        return [self.extract_id(link) for link in parent_links]
 
     def extract_monthly_data(self, response, var_name):
         """Extract the JavaScript arrays containing monthly data

--- a/tests/pages/expected_items.py
+++ b/tests/pages/expected_items.py
@@ -40,7 +40,7 @@ expected_items = {
         ),
         "three-oclock-rock": Area(
             _id=108543607,
-            parent_id=106006698,
+            ancestors=[105708966, 108471385, 106006698],
             name="Three O'clock Rock",
             link="https://www.mountainproject.com/area/108543607/three-oclock-rock",
             latitude=48.159,
@@ -91,7 +91,7 @@ expected_items = {
         ),
         "ooh-la-la": Area(
             _id=105746817,
-            parent_id=105802014,
+            ancestors=[105708956, 105744466, 105802014],
             name="\"Ooh La La!\"",
             link="https://www.mountainproject.com/area/105746817/ooh-la-la",
             latitude=40.162,
@@ -144,7 +144,7 @@ expected_items = {
     "routes": {
         "ooh-la-la-express": Route(
             _id=105764061,
-            parent_id=105746817,
+            ancestors=[105708956, 105744466, 105802014, 105746817],
             name="Ooh La La Express",
             types=["Trad", "Snow", "Alpine"],
             rating=2,
@@ -157,7 +157,7 @@ expected_items = {
         ),
         "liberty-ridge": Route(
             _id=106459197,
-            parent_id=105877031,
+            ancestors=[105708966, 108471329, 105877031],
             name="Liberty Ridge",
             types=["Ice", "Snow", "Alpine"],
             rating=3.8,
@@ -171,7 +171,7 @@ expected_items = {
         ),
         "upper-exum-ridge": Route(
             _id=105933562,
-            parent_id=105803123,
+            ancestors=[105708960, 105802912, 105803123],
             name="Upper Exum Ridge",
             types=["Trad", "Alpine"],
             rating=3.6,
@@ -185,7 +185,7 @@ expected_items = {
         ),
         "the-moonlight-buttress-free": Route(
             _id=106138026,
-            parent_id=105717003,
+            ancestors=[105708957, 105716799, 105717003],
             name="The Moonlight Buttress (Free)",
             types=["Trad"],
             rating=3.9,
@@ -198,7 +198,7 @@ expected_items = {
         ),
         "the-original-route": Route(
             _id=105732410,
-            parent_id=105732183,
+            ancestors=[105708961, 113755154, 105731932, 105731974, 105732183],
             name="The Original Route",
             types=["Trad"],
             rating=4,
@@ -211,7 +211,14 @@ expected_items = {
         ),
         "regular-northwest-face-of-half-dome": Route(
             _id=105912416,
-            parent_id=114557650,
+            ancestors=[
+                105708959,
+                105833381,
+                105833388,
+                118097922,
+                105833395,
+                114557650
+            ],
             name="Regular Northwest Face of Half Dome",
             types=["Trad", "Aid"],
             rating=3.9,
@@ -226,7 +233,7 @@ expected_items = {
         ),
         "moby-grape": Route(
             _id=105884815,
-            parent_id=107340355,
+            ancestors=[105872225, 107340274, 107340355],
             name="Moby Grape",
             types=["Trad", "Alpine"],
             rating=3.8,
@@ -241,7 +248,7 @@ expected_items = {
         ),
         "invisible-touch": Route(
             _id=109513995,
-            parent_id=109255860,
+            ancestors=[105812481, 109253227, 110040864, 109255860],
             name="Invisible Touch",
             types=["Boulder"],
             rating=4,
@@ -252,7 +259,7 @@ expected_items = {
         ),
         "planet-of-the-apes": Route(
             _id=106318953,
-            parent_id=105880707,
+            ancestors=[105708957, 105880382, 105880388, 105880707],
             name="Planet of the Apes",
             types=["Boulder"],
             height=12,
@@ -264,7 +271,7 @@ expected_items = {
         ),
         "the-red-house-extension": Route(
             _id=108027966,
-            parent_id=106031921,
+            ancestors=[105887760, 106031921],
             name="The Red House Extension",
             types=["Boulder"],
             height=15,
@@ -276,7 +283,7 @@ expected_items = {
         ),
         "feels-like-grit": Route(
             _id=105938571,
-            parent_id=105880408,
+            ancestors=[105708957, 105880382, 105880391, 105880408],
             name="Feels Like Grit",
             types=["Boulder"],
             height=15,
@@ -288,7 +295,7 @@ expected_items = {
         ),
         "black-dike": Route(
             _id=105890633,
-            parent_id=106099665,
+            ancestors=[105872225, 106099658, 114088875, 106099665],
             name="Black Dike",
             types=["Mixed", "Ice"],
             height=500,
@@ -304,7 +311,7 @@ expected_items = {
         ),
         "ames-ice-hose": Route(
             _id=105747549,
-            parent_id=105747000,
+            ancestors=[105708956, 105807296, 105744518, 105747000],
             name="Ames Ice Hose",
             types=["Trad", "Mixed", "Ice"],
             height=520,
@@ -320,7 +327,14 @@ expected_items = {
         ),
         "cosmiques-arete": Route(
             _id=107497087,
-            parent_id=110824971,
+            ancestors=[
+                105907743,
+                106660030,
+                106192575,
+                110824749,
+                110824830,
+                110824971
+            ],
             name="Cosmiques Arête",
             types=["Trad", "Mixed", "Ice", "Snow", "Alpine"],
             height=1000,
@@ -337,7 +351,7 @@ expected_items = {
         ),
         "skylight": Route(
             _id=105747482,
-            parent_id=105746985,
+            ancestors=[105708956, 105807296, 105744521, 105746985],
             name="Skylight",
             types=["Trad", "Mixed", "Ice"],
             pitches=3,
@@ -351,7 +365,14 @@ expected_items = {
         ),
         "rock": Route(
             _id=107350537,
-            parent_id=107282156,
+            ancestors=[
+                105852400,
+                110848199,
+                106477419,
+                107281942,
+                107281993,
+                107282156
+            ],
             name="Rock",
             types=["Boulder"],
             height=8,


### PR DESCRIPTION
While working on building aggregations I realized that the parent linked tree structure I had set up was inadequate for some of the things I wanted to do. Specifically per-area route metadata statistics (eg. how many of a specific type of route are in an area) would be prohibitively difficult (at least with my current knowledge of MongoDB).

To address this, I replaced the `parent_id` field with an `ancestors` field which contains an ordered list of a given resource's ancestors where the 0th index is the topmost parent. I chose to exclude the default topmost resource (the route guide) because at that point I'm just searching the entire dataset so I could perform a query on the route or area collection as a whole.