### PR TITLE
Move lat/long to coords array

### DIFF
--- a/mp_scraper/items.py
+++ b/mp_scraper/items.py
@@ -5,6 +5,7 @@ from scrapy.loader import ItemLoader
 
 to_int = Compose(TakeFirst(), int)
 to_float = Compose(TakeFirst(), float)
+iter_to_float = lambda iter: [float(val) for val in iter]
 strip = Compose(TakeFirst(), lambda value: value.strip())
 
 
@@ -16,8 +17,7 @@ class Area(scrapy.Item):
     _id = scrapy.Field()
     ancestors = scrapy.Field(output_processor=Identity())
     name = scrapy.Field(input_processor=strip)
-    latitude = scrapy.Field(input_processor=to_float)
-    longitude = scrapy.Field(input_processor=to_float)
+    coords = scrapy.Field(input_processor=iter_to_float, output_processor=Identity())
     elevation = scrapy.Field(input_processor=Join(""), output_processor=to_int)
     link = scrapy.Field()
     temp_avgs = scrapy.Field(output_processor=Identity())

--- a/mp_scraper/spiders/mp.py
+++ b/mp_scraper/spiders/mp.py
@@ -45,9 +45,8 @@ class MpSpider(CrawlSpider):
 
         details_css = "table.description-details td::text"
         coords = response.css(details_css).re(
-            r"(-?\d+(?:\.\d+)?),\s(-?\d+(?:\.\d+)?)")
-        area_loader.add_value("latitude", coords[0])
-        area_loader.add_value("longitude", coords[1])
+            r"(-?\d+(?:\.\d+)?),\s(-?\d+(?:\.\d+)?)")[:2]
+        area_loader.add_value("coords", coords)
         area_loader.add_css("elevation", details_css, re=r"(\d+),?(\d+) ft")
 
         area_loader.add_value(

--- a/tests/pages/expected_items.py
+++ b/tests/pages/expected_items.py
@@ -5,8 +5,7 @@ expected_items = {
         "north-dakota": Area(
             _id=106598130,
             name="North Dakota",
-            latitude=47.14,
-            longitude=-100.433,
+            coords=[47.14, -100.433],
             elevation=1000,
             link="https://www.mountainproject.com/area/106598130/north-dakota",
             temp_avgs=[
@@ -43,8 +42,7 @@ expected_items = {
             ancestors=[105708966, 108471385, 106006698],
             name="Three O'clock Rock",
             link="https://www.mountainproject.com/area/108543607/three-oclock-rock",
-            latitude=48.159,
-            longitude=-121.617,
+            coords=[48.159, -121.617],
             elevation=2652,
             temp_avgs=[
                 {"month": 1, "avg_high": 41, "avg_low": 28},
@@ -94,8 +92,7 @@ expected_items = {
             ancestors=[105708956, 105744466, 105802014],
             name="\"Ooh La La!\"",
             link="https://www.mountainproject.com/area/105746817/ooh-la-la",
-            latitude=40.162,
-            longitude=-105.668,
+            coords=[40.162, -105.668],
             elevation=12945,
             temp_avgs=[
                 {"month": 1, "avg_low": 3, "avg_high": 38},


### PR DESCRIPTION
MongoDB wants geospatial data to be in an array, this update does just that.